### PR TITLE
Disable sh:minCount Constraint on AgentShape

### DIFF
--- a/Formulasation(shacl)/core/PiecesShape/Catalog.ttl
+++ b/Formulasation(shacl)/core/PiecesShape/Catalog.ttl
@@ -71,7 +71,7 @@
     sh:nodeKind sh:Literal ;
     dash:editor dash:TextFieldEditor ;
     dash:viewer dash:LiteralViewer ;
-    sh:minCount 1 ;
+    #sh:minCount 1 ;
     sh:maxCount 1 ;
   ];
   

--- a/Formulasation(shacl)/core/PiecesShape/Dataset.ttl
+++ b/Formulasation(shacl)/core/PiecesShape/Dataset.ttl
@@ -180,7 +180,7 @@
     sh:nodeKind sh:Literal ;
     dash:editor dash:TextFieldEditor ;
     dash:viewer dash:LiteralViewer ;
-    sh:minCount 1 ;
+   # sh:minCount 1 ;
     sh:maxCount 1 ;
   ];
 


### PR DESCRIPTION
Changes:
Removed sh:minCount from AgentShape properties.

Impact:
Loosens validation rules, making AgentShape properties optional and thus increasing compatibility with diverse datasets that may lack these fields.

Testing:
Save change to FDP it self

Reason for Change:
Ttrying to update the FDP itself still gives ''Unable to update entity data''. I have not created any specific entries yet, e.g. catalogs etc.