### PR TITLE
Prefix healthdcatap

### DIFF
--- a/Formulasation(shacl)/core/PiecesShape/Catalog.ttl
+++ b/Formulasation(shacl)/core/PiecesShape/Catalog.ttl
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2024 Health-ri.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
 @prefix :         <http://fairdatapoint.org/> .
 @prefix dash:     <http://datashapes.org/dash#> .
 @prefix dcat:     <http://www.w3.org/ns/dcat#> .

--- a/Formulasation(shacl)/core/PiecesShape/DataService.ttl
+++ b/Formulasation(shacl)/core/PiecesShape/DataService.ttl
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Health-ri.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 @prefix :  <http://fairdatapoint.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .

--- a/Formulasation(shacl)/core/PiecesShape/Dataset.ttl
+++ b/Formulasation(shacl)/core/PiecesShape/Dataset.ttl
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Health-ri.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 @prefix :         <http://fairdatapoint.org/> .
 @prefix dash:     <http://datashapes.org/dash#> .
 @prefix dcat:     <http://www.w3.org/ns/dcat#> .

--- a/Formulasation(shacl)/core/PiecesShape/Dataset.ttl
+++ b/Formulasation(shacl)/core/PiecesShape/Dataset.ttl
@@ -6,7 +6,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
-@prefix healthdcat: <http://example.com/ns/healthdcat#> .
+@prefix healthdcatap: <http://example.com/ns/healthdcatap#> .
 @prefix : <http://coreRule-healthri.nl#> .
 
 :DatasetShape a sh:NodeShape ;
@@ -117,7 +117,7 @@
     dash:viewer dash:LiteralViewer ;
   ],
   [
-    sh:path healthdcat:minTypicalAge ;
+    sh:path healthdcatap:minTypicalAge ;
     sh:nodeKind sh:Literal ;
     # sh:datatype xsd:nonnegativeinteger ;
     sh:name "Mininum typical age of the population within the dataset" ;
@@ -126,7 +126,7 @@
     dash:viewer dash:LiteralViewer;
   ],
   [
-    sh:path healthdcat:maxTypicalAge ;
+    sh:path healthdcatap:maxTypicalAge ;
     sh:nodeKind sh:Literal ;
     # sh:datatype xsd:nonnegativeinteger ;
     sh:name "Maximum typical age of the population within the dataset" ;
@@ -135,7 +135,7 @@
     dash:viewer dash:LiteralViewer;
   ],
   [
-    sh:path healthdcat:numberOfUniqueIndividuals ;
+    sh:path healthdcatap:numberOfUniqueIndividuals ;
     sh:nodeKind sh:Literal ;
     # sh:datatype xsd:nonnegativeinteger ;
     sh:name "Number of unique individuals" ;
@@ -145,7 +145,7 @@
     dash:viewer dash:LiteralViewer;
   ],
   [
-    sh:path healthdcat:numberOfRecords ;
+    sh:path healthdcatap:numberOfRecords ;
     sh:nodeKind sh:Literal ;
     # sh:datatype xsd:nonnegativeinteger ;
     sh:name "Number of records" ;
@@ -155,7 +155,7 @@
     dash:viewer dash:LiteralViewer;
   ],
   [
-    sh:path healthdcat:populationCoverage ;
+    sh:path healthdcatap:populationCoverage ;
     sh:name "Population coverage (a definition of the population within a dataset)" ;
     sh:datatype xsd:string ;
     sh:nodeKind  sh:Literal;

--- a/Formulasation(shacl)/core/PiecesShape/DatasetSeries.ttl
+++ b/Formulasation(shacl)/core/PiecesShape/DatasetSeries.ttl
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Health-ri.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .

--- a/Formulasation(shacl)/core/PiecesShape/Distribution.ttl
+++ b/Formulasation(shacl)/core/PiecesShape/Distribution.ttl
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Health-ri.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 @prefix :         <http://fairdatapoint.org/> .
 @prefix dash:     <http://datashapes.org/dash#> .
 @prefix dcat:     <http://www.w3.org/ns/dcat#> .

--- a/Formulasation(shacl)/core/PiecesShape/Resource.ttl
+++ b/Formulasation(shacl)/core/PiecesShape/Resource.ttl
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Health-ri.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 @prefix :         <http://fairdatapoint.org/> .
 @prefix dash:     <http://datashapes.org/dash#> .
 @prefix dcat:     <http://www.w3.org/ns/dcat#> .


### PR DESCRIPTION
Change prefix to healthdcatap instead of healthdcat



https://healthdcat-ap.github.io/#rdf-examples 
at the beginning of section 5.1, it suggested the namespace prefix is: healthdcatap

 