### PR TITLE
Custom CA shell scripts

### DIFF
--- a/schema-tool/README.md
+++ b/schema-tool/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2026 Molecular Medicine Center
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Schema Tool
 
 Scripts for running the FDP Schema Update Tool with optional custom CA trust.

--- a/schema-tool/README.md
+++ b/schema-tool/README.md
@@ -1,0 +1,54 @@
+# Schema Tool
+
+Scripts for running the FDP Schema Update Tool with optional custom CA trust.
+
+## Configuration
+
+Copy `.env.example` to `.env` and fill in:
+
+```env
+FDP_HOST=https://your-fdp-host.org
+FDP_USER=user@example.org
+FDP_PWD=your-password
+PROPERTIES_LOCATION=./Properties.yaml
+```
+
+## Scripts
+
+### `run.sh`
+
+Runs the schema update tool against the configured FDP instance.
+
+```sh
+# Without custom CA
+./run.sh
+
+# With custom CA truststore
+./run.sh truststore.jks
+```
+
+Reads credentials from `.env`. When a truststore is provided, it is mounted into the container and the JVM is configured to use it.
+
+### `custom_ca.sh`
+
+Generates a Java truststore (`truststore.jks`) containing the default JVM certificates plus a custom CA certificate.
+
+```sh
+# Using default file ./my-ca.crt
+./custom_ca.sh
+
+# Using a specific certificate file
+./custom_ca.sh /path/to/my-ca.crt
+```
+
+The resulting `truststore.jks` is written to the current directory and can be passed to `run.sh`.
+
+## Typical workflow
+
+```sh
+# 1. Generate truststore from your CA certificate
+./custom_ca.sh my-ca.crt
+
+# 2. Run the schema tool with the truststore
+./run.sh truststore.jks
+```

--- a/schema-tool/README.md
+++ b/schema-tool/README.md
@@ -1,4 +1,5 @@
 <!--
+SPDX-FileCopyrightText: 2024 Health-RI.
 SPDX-FileCopyrightText: 2026 Molecular Medicine Center
 
 SPDX-License-Identifier: CC-BY-4.0

--- a/schema-tool/custom_ca.sh
+++ b/schema-tool/custom_ca.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+# SPDX-FileCopyrightText: 2026 Molecular Medicine Center
+# 
+# SPDX-License-Identifier: Apache-2.0
+
 # Use first argument as CRT file, default to ./my-ca.crt
 CRT_FILE="${1:-./my-ca.crt}"
 

--- a/schema-tool/custom_ca.sh
+++ b/schema-tool/custom_ca.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# Use first argument as CRT file, default to ./my-ca.crt
+CRT_FILE="${1:-./my-ca.crt}"
+
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+  echo "Usage: $0 [CRT_FILE]"
+  echo "Mounts CRT_FILE into the container and imports it into a truststore (output/truststore.jks)."
+  echo "Default CRT_FILE: ./my-ca.crt"
+  exit 0
+fi
+
+if [ ! -f "$CRT_FILE" ]; then
+  echo "Error: CRT file not found: $CRT_FILE" >&2
+  exit 2
+fi
+
+# Derive alias from filename (basename without extension)
+ALIAS=$(basename "$CRT_FILE")
+ALIAS=${ALIAS%.*}
+
+docker run --rm \
+  -v "$CRT_FILE":/tmp/my-ca.crt:ro \
+  -v "$PWD":/output \
+  --entrypoint sh \
+  healthri/fdp-schema-update-tool:1.0.4 \
+  -c 'cp $JAVA_HOME/lib/security/cacerts /output/truststore.jks && \
+    keytool -importcert -keystore /output/truststore.jks -storepass changeit -noprompt -alias '"$ALIAS"' -file /tmp/my-ca.crt'

--- a/schema-tool/custom_ca.sh
+++ b/schema-tool/custom_ca.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
+# SPDX-FileCopyrightText: 2025 Health-RI
 # SPDX-FileCopyrightText: 2026 Molecular Medicine Center
-# 
+#
 # SPDX-License-Identifier: Apache-2.0
 
 # Use first argument as CRT file, default to ./my-ca.crt

--- a/schema-tool/run.sh
+++ b/schema-tool/run.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+# SPDX-FileCopyrightText: 2026 Molecular Medicine Center
+# 
+# SPDX-License-Identifier: Apache-2.0
+
 # Usage: ./run.sh [truststore.jks]
 # Runs the schema tool with optional custom truststore for CA trust.
 

--- a/schema-tool/run.sh
+++ b/schema-tool/run.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
+# SPDX-FileCopyrightText: 2025 Health-RI
 # SPDX-FileCopyrightText: 2026 Molecular Medicine Center
-# 
+#
 # SPDX-License-Identifier: Apache-2.0
 
 # Usage: ./run.sh [truststore.jks]

--- a/schema-tool/run.sh
+++ b/schema-tool/run.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# Usage: ./run.sh [truststore.jks]
+# Runs the schema tool with optional custom truststore for CA trust.
+
+set -e
+
+# Source .env file
+if [ -f .env ]; then
+  . ./.env
+fi
+
+TRUSTSTORE="${1:-}"
+
+DOCKER_ARGS="--rm --network host"
+DOCKER_ARGS="$DOCKER_ARGS -v ${PROPERTIES_LOCATION}:/opt/app/Properties.yaml:ro"
+
+if [ -n "$TRUSTSTORE" ]; then
+  if [ ! -f "$TRUSTSTORE" ]; then
+    echo "Error: truststore not found: $TRUSTSTORE" >&2
+    exit 2
+  fi
+  DOCKER_ARGS="$DOCKER_ARGS -v $(cd "$(dirname "$TRUSTSTORE")" && pwd)/$(basename "$TRUSTSTORE"):/opt/app/truststore.jks:ro"
+  DOCKER_ARGS="$DOCKER_ARGS -e JAVA_TOOL_OPTIONS='-Djavax.net.ssl.trustStore=/opt/app/truststore.jks -Djavax.net.ssl.trustStorePassword=changeit'"
+fi
+
+eval docker run $DOCKER_ARGS \
+  healthri/fdp-schema-update-tool:1.0.4 \
+  -h "$FDP_HOST" -u "$FDP_USER" -p "$FDP_PWD"


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2024 PNED G.I.E. -->

<!-- SPDX-License-Identifier: Apache-2.0 -->

## 🚀 Pull Request Checklist

- **Title:** Custom CA Shell scripts

- **Description:**
  Add a couple of shell scripts that allow the FDP Schema Update Tool to be executed against an endpoint served with a Custom CA Certificate.

- **Context:** Some FDP endpoints might be served with custom Certificate Authorities. This allows for flexible addition of trusted Root certificates at runtime without rebuilding the docker image.

- **Changes:**
  - Added: A couple of shell scripts. The first allows for the creation of a custom trust store. The second allows for the usage of the trust store.

- **Testing:**
  - The shell scripts have been used to apply the schema definitions to two instances (dev and staging) at the Bulgarian GDI node.

- **Screenshots (if applicable):**
  - NA

- **Additional Information:**
  - NA

- **Checklist:**
  - [x] I have checked that my code adheres to the project's style guidelines and that my code is well-commented.
  - [x] I have performed self-review of my own code and corrected any misspellings.
  - [x] I have made corresponding changes to the documentation (if applicable).
  - [x] My changes generate no new warnings or errors.
  - [ ] I have added tests that prove my fix is effective or that my feature works.
  - [ ] New and existing unit tests pass locally with my changes.